### PR TITLE
リンク切れを修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ New Stickney配列は現行のJISかな配列のもととなったバーナム�
 
 New Stickneyかな配列は、物理的なキー配置としては英語圏にかぎらず今日世界中でひろくつかわれている英語キーボードのキー配置での利用を想定しています。
 
-※ 最新の小学生むけの[説明書](https://esrille.github.io/ibus-replace-with-kanji/layouts.html)もあわせて参照してください。
+※ 最新の小学生むけの[説明書](https://esrille.github.io/ibus-hiragana/layouts.html)もあわせて参照してください。
 
 ## AutoHotKey スクリプトの使用方法
 


### PR DESCRIPTION
些事ですが，小学生むけの説明書へのリンクが切れていましたので修正しました。
なお，修正前のリンク先との同一性は，[Web保管庫にあるページ](http://web.archive.org/web/20200130013313/https://esrille.github.io/ibus-replace-with-kanji/layouts.html)およびURL名を参考にして推定しています。
